### PR TITLE
Fix stdio_deregister_dev(...) device name comparison

### DIFF
--- a/common/stdio.c
+++ b/common/stdio.c
@@ -251,7 +251,7 @@ int stdio_register(struct stdio_dev *dev)
 int stdio_deregister_dev(struct stdio_dev *dev, int force)
 {
 	struct list_head *pos;
-	char temp_names[3][16];
+	char temp_names[3][32];
 	int i;
 
 	/* get stdio devices (ListRemoveItem changes the dev list) */


### PR DESCRIPTION
String comparison does not match 32 bytes length of dev->name.
Need to align temp_names to match stdio_dev.h:27 from 16 bytes to 32 bytes.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
